### PR TITLE
check if match() returned anything

### DIFF
--- a/js/queryLoader.js
+++ b/js/queryLoader.js
@@ -34,9 +34,11 @@ var QueryLoader = {
 	
 	ieLoadFix: function() {
 		var ie = navigator.userAgent.match(/MSIE (\d+(?:\.\d+)+(?:b\d*)?)/);
-		if (ie[0].match("MSIE")) {
-			while ((100 / QueryLoader.doneStatus) * QueryLoader.doneNow < 100) {
-				QueryLoader.imgCallback();
+		if (ie) {
+			if (ie[0].match("MSIE")) {
+				while ((100 / QueryLoader.doneStatus) * QueryLoader.doneNow < 100) {
+					QueryLoader.imgCallback();
+				}
 			}
 		}
 	},


### PR DESCRIPTION
Added check if "`navigator.userAgent.match()`" on line 36 returned anything, because when it was null the condition "`if (ie[0].match("MSIE"))`" threw an error as there was no property [0].

![image](https://user-images.githubusercontent.com/25987075/38074548-552aa098-332f-11e8-9c27-d32147934e5e.png)
